### PR TITLE
Issue 1 branch fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zendro-env",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Zendro tooling to setup and manage a testing environment",
   "bin": {
     "zendro-env": "./bin/zendro-env"

--- a/src/commands/branch.js
+++ b/src/commands/branch.js
@@ -55,6 +55,7 @@ const updateTemplateDependencies = (title, name, verbose) => {
 
   // Matching template definition
   const template = config.templates.find(template => template.name === name);
+  const templateCwdPath = expandPath(template.name);
 
   // Associated services
   const services = config.services.filter(service => service.template === name);
@@ -72,24 +73,24 @@ const updateTemplateDependencies = (title, name, verbose) => {
     task: () => new Listr(
       services.map(service => {
 
-        const serviceRelativePath = expandPath(service.name);
+        const serviceCwdPath = expandPath(service.name);
 
         return {
 
           title: `${service.name}`,
 
-          skip: async () => await checkWorkspace(cwd, serviceRelativePath)
+          skip: async () => await checkWorkspace(cwd, serviceCwdPath)
             ? false
             : 'Service is not installed',
 
           task: () => new Listr([
             {
               title: 'Remove existing service',
-              task: () => resetEnvironment(cwd, serviceRelativePath),
+              task: () => resetEnvironment(cwd, serviceCwdPath),
             },
             {
               title: 'Clone service',
-              task: () => cloneService(cwd, template.name, service.name, verbose)
+              task: () => cloneService(cwd, templateCwdPath, serviceCwdPath, verbose)
             },
           ]),
 

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -82,7 +82,7 @@ const setupServices = (title, cwd, services, verbose, enabled) => ({
       task: () => new Listr(
         services.map(({ template, name }) => ({
           title: name,
-          task: () => cloneService(cwd, expandPath(template), name, verbose),
+          task: () => cloneService(cwd, expandPath(template), expandPath(name), verbose),
         })),
         {
           concurrent: !verbose,


### PR DESCRIPTION
## Issue

Closes #1.

## Description

Update `updateTemplateDependencies` task in `branch` to use the new signature of `cloneService` that requires service and template relative paths.

## Changes

- Refactor `cloneService` handler signature to also receive a service relative path from `cwd`, like it already did with the template.
- Refactor `cloneService` to rename `package.json#name` using the last segment of the passed service relative path.
- Fix `updateTemplateDependencies` to use the new signature of `cloneService`
- Bumped to patch version `0.6.7`

## Blocks

None.